### PR TITLE
Add field_model to dmp and funding.

### DIFF
--- a/islandora_rdm_data_management_plan/config/install/field.field.node.data_management_plan.field_model.yml
+++ b/islandora_rdm_data_management_plan/config/install/field.field.node.data_management_plan.field_model.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_model
+    - node.type.data_management_plan
+    - taxonomy.vocabulary.islandora_models
+id: node.data_management_plan.field_model
+field_name: field_model
+entity_type: node
+bundle: data_management_plan
+label: Model
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_models: islandora_models
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/islandora_rdm_types/config/install/field.field.node.funding_information.field_model.yml
+++ b/islandora_rdm_types/config/install/field.field.node.funding_information.field_model.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_model
+    - node.type.funding_information
+    - taxonomy.vocabulary.islandora_models
+id: node.funding_information.field_model
+field_name: field_model
+entity_type: node
+bundle: funding_information
+label: Model
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_models: islandora_models
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference


### PR DESCRIPTION
This should add field_model to the Funding Info and DMP types. It was not there already.

It is not listed in the view mode or form configs, and after installing the field through this feature, the field is "hidden". 

fingers crossed.